### PR TITLE
feat: add character hp calculations and methods

### DIFF
--- a/src/model/characters/character.ts
+++ b/src/model/characters/character.ts
@@ -1,17 +1,18 @@
 export default class Character {
-  name: string;
-  age: number;
-  race: Race;
+  public name: string;
+  public age: number;
+  public race: Race;
   strength: number;
   intelligence: number;
   piety: number;
   vitality: number;
   agility: number;
   luck: number;
-  class: ClassName;
+  class: Class;
   level: number;
   exp: number;
-  hp: number;
+  #hp: number;
+  #maxHp: number;
   status: Status;
   alignment: Alignment;
 
@@ -19,7 +20,7 @@ export default class Character {
     name: string,
     race: Race,
     stats: Record<Stat, number>,
-    charClass: ClassName,
+    charClass: Class,
     alignment: Alignment,
     level = 1
   ) {
@@ -38,9 +39,45 @@ export default class Character {
     this.level = level;
     this.exp = 0;
 
-    this.hp = 10;
+    this.#maxHp = this.#getStartHp();
+    this.#hp = this.#maxHp;
     this.status = 'OK';
     this.alignment = alignment;
+  }
+
+  public setHp(value = this.#maxHp) {
+    this.#hp = value > this.#maxHp ? this.#maxHp : value;
+  }
+
+  public getHp() {
+    return this.#hp;
+  }
+
+  #rollMaxHp(): void {
+    const vitMod = this.#getVitMod();
+    let hp = this.#getStartHp();
+
+    for (let i = 0; i < this.level - 1; i += 1) {
+      hp += Math.floor(Math.random() * this.class.hitDice + 1) + vitMod;
+    }
+
+    this.#maxHp = this.#maxHp >= hp ? (this.#maxHp += 1) : hp;
+  }
+
+  #getVitMod(): number {
+    let vitMod = 0;
+
+    if (this.vitality > 15) vitMod = this.vitality - 15;
+    if (this.vitality < 6) vitMod = -1;
+    if (this.vitality === 3) vitMod = -2;
+
+    return vitMod;
+  }
+
+  #getStartHp(): number {
+    const vitMod = this.#getVitMod();
+    const samMod = this.class.name === 'samurai' ? 2 : 1;
+    return samMod * this.class.hitDice + vitMod;
   }
 
   attack() {

--- a/src/model/characters/characterCreator.ts
+++ b/src/model/characters/characterCreator.ts
@@ -35,7 +35,7 @@ export function getClasses(alignment: Alignment, stats: Record<Stat, number>) {
       return stats[key as Stat] >= value;
     });
 
-  return classes
+  return Object.values(classes)
     .filter(
       (charClass) =>
         isQualified(charClass.stats) && charClass.alignment.includes(alignment)
@@ -47,7 +47,7 @@ export function getCharacter(
   name: string,
   race: Race,
   stats: Record<Stat, number>,
-  className: ClassName,
+  className: Class,
   alignment: Alignment
 ) {
   return new Character(name, race, stats, className, alignment);

--- a/src/model/data/classes.ts
+++ b/src/model/data/classes.ts
@@ -1,41 +1,46 @@
-export default [
-  {
-    name: 'fighter',
+export default {
+  fighter: {
+    name: 'fighter' as ClassName,
     stats: {
       strength: 11,
     },
-    alignment: ['good', 'neutral', 'evil'],
+    alignment: ['good', 'neutral', 'evil'] as Alignment[],
+    hitDice: 10,
   },
-  {
+  mage: {
     name: 'mage',
     stats: {
       intelligence: 11,
     },
     alignment: ['good', 'neutral', 'evil'],
+    hitDice: 4,
   },
-  {
+  priest: {
     name: 'priest',
     stats: {
       piety: 11,
     },
     alignment: ['good', 'evil'],
+    hitDice: 8,
   },
-  {
+  thief: {
     name: 'thief',
     stats: {
       agility: 11,
     },
     alignment: ['neutral', 'evil'],
+    hitDice: 6,
   },
-  {
+  bishop: {
     name: 'bishop',
     stats: {
       intelligence: 12,
       piety: 12,
     },
     alignment: ['good', 'evil'],
+    hitDice: 6,
   },
-  {
+  samurai: {
     name: 'samurai',
     stats: {
       strength: 15,
@@ -45,8 +50,9 @@ export default [
       agility: 10,
     },
     alignment: ['good', 'neutral'],
+    hitDice: 8,
   },
-  {
+  lord: {
     name: 'lord',
     stats: {
       strength: 15,
@@ -57,8 +63,9 @@ export default [
       luck: 15,
     },
     alignment: ['good'],
+    hitDice: 10,
   },
-  {
+  ninja: {
     name: 'ninja',
     stats: {
       strength: 17,
@@ -69,5 +76,6 @@ export default [
       luck: 17,
     },
     alignment: ['evil'],
+    hitDice: 6,
   },
-];
+};

--- a/src/tests/character.spec.ts
+++ b/src/tests/character.spec.ts
@@ -1,0 +1,27 @@
+import Character from '../model/characters/character';
+import classes from '../model/data/classes';
+
+const getStats = (vitality: number) => {
+  return {
+    strength: 18,
+    intelligence: 18,
+    piety: 18,
+    vitality: vitality,
+    agility: 18,
+    luck: 18,
+  };
+};
+
+describe('character hp should depend on class hitDice', () => {
+  test(`starting hp should be ${classes.fighter.hitDice} + vitality mod for a fighter`, () => {
+    const fighter = new Character(
+      'Grognak',
+      'human',
+      getStats(18),
+      classes.fighter,
+      'good'
+    );
+
+    expect(fighter.getHp()).toEqual(classes.fighter.hitDice + 3);
+  });
+});

--- a/src/tests/characterCreator.spec.ts
+++ b/src/tests/characterCreator.spec.ts
@@ -33,16 +33,16 @@ describe('getClasses()', () => {
     'luck',
   ];
 
-  const classNames = classes.map((item) => item.name);
-  const good = classes
+  const classNames = Object.values(classes).map((item) => item.name);
+  const good = Object.values(classes)
     .filter((item) => item.alignment.includes('good'))
     .map((item) => item.name)
     .sort();
-  const evil = classes
+  const evil = Object.values(classes)
     .filter((item) => item.alignment.includes('evil'))
     .map((item) => item.name)
     .sort();
-  const neutral = classes
+  const neutral = Object.values(classes)
     .filter((item) => item.alignment.includes('neutral'))
     .map((item) => item.name)
     .sort();

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -30,6 +30,13 @@ type ClassName =
   | 'lord'
   | 'ninja';
 
+type Class = {
+  name: ClassName;
+  stats: Partial<Record<Stat, number>>;
+  alignment: Alignment[];
+  hitDice: number;
+};
+
 type ItemTypes = 'weapon' | 'shield' | 'armor' | 'helmet' | 'gauntlet';
 
 type Item = {


### PR DESCRIPTION
1. Add calculations for starting and max hp
2. Add `getHp()` and `setHp(value?: number)` methods  
    - `getHp()` returns character's current hp
    - `setHp(value?: number)` sets  character's current hp to `value` or to `maxHp`, if value is omitted

These methods are needed to implement Temple of Cant functionality